### PR TITLE
Dont send key as data and clean up logging

### DIFF
--- a/jest-reporter.js
+++ b/jest-reporter.js
@@ -4,20 +4,18 @@ const fs = require('fs')
 const path = require('path');
 const CI = require('./src/ci')
 
+const debug = (text) => {
+  if (process.env.BUILDKITE_ANALYTICS_DEBUG === "true") {
+    console.log(text)
+  }
+}
+
 class JestBuildkiteAnalyticsReporter {
   constructor(globalConfig, options) {
     this._buildkiteAnalyticsKey = process.env.BUILDKITE_ANALYTICS_KEY
     this._globalConfig = globalConfig
     this._options = options
     this._testResults = []
-    this.debugEnabled = !!process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED
-    this.debugFilepath = process.env.BUILDKITE_ANALYTICS_DEBUG_FILEPATH || (process.cwd() + '/buildkite-analytics.log')
-  }
-
-  log(message) {
-    if(this.debugEnabled) {
-      fs.appendFile(this.debugFilepath, message + "\n", () => { })
-    }
   }
 
   onRunStart(test) {
@@ -41,17 +39,19 @@ class JestBuildkiteAnalyticsReporter {
       }
     }
 
+    debug(`Posting to Test Analytics: ${JSON.stringify(data)}`)
+
     axios.post('https://analytics-api.buildkite.com/v1/uploads', data, config)
     .then(function (response) {
-      this.log('Analytics successfully uploaded to Buildkite')
-    }.bind(this))
+      debug(`Test Analytics success response: ${JSON.stringify(response.data)}`)
+    })
     .catch(function (error) {
       if (error.response) {
-        this.log(`Error, response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
+        console.error(`Test Analytics error response: ${error.response.status} ${error.response.statusText} ${JSON.stringify(error.response.data)}`);
       } else {
-        this.log(`Error, ${error.message}`)
+        console.error(`Test Analytics error: ${error.message}`)
       }
-    }.bind(this))
+    })
   }
 
   onTestStart(test) {

--- a/jest-reporter.js
+++ b/jest-reporter.js
@@ -24,6 +24,11 @@ class JestBuildkiteAnalyticsReporter {
   }
 
   onRunComplete(test, results) {
+    if (!this._buildkiteAnalyticsKey) {
+      console.error('Missing BUILDKITE_ANALYTICS_KEY')
+      return
+    }
+
     let data = {
       'format': 'json',
       'run_env': (new CI()).env(),

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## Jest
 
-1) Setup a project on [Buildkite Test Analtics](https://buildkite.com/test-analytics) and note the key
+1) Setup a project on [Buildkite Test Analytics](https://buildkite.com/test-analytics) and note the key
 2) Add 'buildkite-analytics' to your npm packages
 3) Configure Jest to use the reporter and enable `testLocationInResults`
 
@@ -17,7 +17,9 @@
 
 4) set the environment variable for your test analytics
 ```sh
-  export BUILDKITE_ANALYTICS_KEY=key-found-on-website
+  export BUILDKITE_ANALYTICS_KEY=xyz
 ```
 
 5) Run your tests
+
+To enable debugging, set `BUILDKITE_ANALYTICS_DEBUG=true`

--- a/src/ci.js
+++ b/src/ci.js
@@ -1,56 +1,30 @@
 const { v4: uuidv4 } = require('uuid')
-const { name: collector, version } = require('.././package.json')
+const { name, version } = require('.././package.json')
 
 class CI {
-  // the analytics env are more specific than the automatic ci platform env.
-  // If they've been specified we'll assume the user wants to use that value instead.
   env() {
     return({
-      ...this.ci_env(),
-      ...this.analytics_env()
+      "version": version,
+      "collector": `js-${name}`,      
+      ...this.ci_env()
     })
-  }
-
-  _stripUndefinedKeys(object) {
-    Object.keys(object).forEach((key) => {
-      if (object[key] === undefined) {
-        delete object[key]
-      }
-    })
-
-    return object
   }
 
   ci_env() {
-    if(process.env.BUILDKITE_BUILD_ID !== undefined) { return(this.buildkite()) }
-    if(process.env.GITHUB_RUN_NUMBER !== undefined) { return(this.github_actions()) }
-    if(process.env.CIRCLE_BUILD_NUM  !== undefined) { return(this.circleci()) }
-    if(process.env.CI !== undefined) { return(this.generic()) }
-
-    return({
-      'CI': undefined,
-      'key': uuidv4()
-    })
-  }
-
-  analytics_env() {
-    return this._stripUndefinedKeys({
-      "key": process.env.BUILDKITE_ANALYTICS_KEY,
-      "url": process.env.BUILDKITE_ANALYTICS_URL,
-      "branch": process.env.BUILDKITE_ANALYTICS_BRANCH,
-      "commit_sha": process.env.BUILDKITE_ANALYTICS_SHA,
-      "number": process.env.BUILDKITE_ANALYTICS_NUMBER,
-      "job_id": process.env.BUILDKITE_ANALYTICS_JOB_ID,
-      "message": process.env.BUILDKITE_ANANLYTICS_MESSAGE,
-      "debug": process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED,
-      "version": version,
-      "collector": `js-${collector}`,
-    })
+    if (process.env.BUILDKITE_BUILD_ID !== undefined) {
+      return(this.buildkite())
+    } else if (process.env.GITHUB_RUN_NUMBER !== undefined) {
+      return(this.github_actions())
+    } else if (process.env.CIRCLE_BUILD_NUM  !== undefined) {
+      return(this.circleci())
+    } else {
+      return(this.generic())
+    }
   }
 
   generic() {
     return({
-      "CI": "generic",
+      "ci": "generic",
       "key": uuidv4(),
     })
   }


### PR DESCRIPTION
In testing we discovered that `BUILDKITE_ANALYTICS_KEY` was being sent through as `"key"`, and everything was being tracked to a single run.

This fixes that, as well as:

* Simplifies the env code so it's a bit easier to reason about
* Adds error console messages if there's genuine problems (as per the official Jest reporters)
* Adds support for debug output to the console, instead of a file