### PR TITLE
Resolve conflict between API Token and Run Key

### DIFF
--- a/jest-reporter.js
+++ b/jest-reporter.js
@@ -5,7 +5,7 @@ const path = require('path');
 const CI = require('./src/ci')
 
 const debug = (text) => {
-  if (process.env.BUILDKITE_ANALYTICS_DEBUG === "true") {
+  if (process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED === "true") {
     console.log(text)
   }
 }

--- a/jest-reporter.js
+++ b/jest-reporter.js
@@ -23,7 +23,7 @@ class JestBuildkiteAnalyticsReporter {
 
   onRunComplete(test, results) {
     if (!this._buildkiteAnalyticsKey) {
-      console.error('Missing BUILDKITE_ANALYTICS_KEY')
+      console.error('Missing BUILDKITE_ANALYTICS_API_TOKEN')
       return
     }
 

--- a/jest-reporter.js
+++ b/jest-reporter.js
@@ -12,7 +12,7 @@ const debug = (text) => {
 
 class JestBuildkiteAnalyticsReporter {
   constructor(globalConfig, options) {
-    this._buildkiteAnalyticsKey = process.env.BUILDKITE_ANALYTICS_KEY
+    this._buildkiteAnalyticsKey = process.env.BUILDKITE_ANALYTICS_API_TOKEN
     this._globalConfig = globalConfig
     this._options = options
     this._testResults = []

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@
 
 4) set the environment variable for your test analytics
 ```sh
-  export BUILDKITE_ANALYTICS_KEY=key-found-on-website
+  export BUILDKITE_ANALYTICS_API_TOKEN=xyz
 ```
 
 5) Run your tests

--- a/readme.md
+++ b/readme.md
@@ -17,9 +17,9 @@
 
 4) set the environment variable for your test analytics
 ```sh
-  export BUILDKITE_ANALYTICS_KEY=xyz
+  export BUILDKITE_ANALYTICS_KEY=key-found-on-website
 ```
 
 5) Run your tests
 
-To enable debugging, set `BUILDKITE_ANALYTICS_DEBUG=true`
+To enable debugging, set `BUILDKITE_ANALYTICS_DEBUG_ENABLED=true`

--- a/src/ci.js
+++ b/src/ci.js
@@ -2,12 +2,23 @@ const { v4: uuidv4 } = require('uuid')
 const { name, version } = require('.././package.json')
 
 class CI {
+  // the analytics env are more specific than the automatic ci platform env.
+  // If they've been specified we'll assume the user wants to use that value instead.
   env() {
     return({
-      "version": version,
-      "collector": `js-${name}`,      
-      ...this.ci_env()
+      ...this.ci_env(),
+      ...this.analytics_env()
     })
+  }
+
+  _stripUndefinedKeys(object) {
+    Object.keys(object).forEach((key) => {
+      if (object[key] === undefined) {
+        delete object[key]
+      }
+    })
+
+    return object
   }
 
   ci_env() {
@@ -20,6 +31,21 @@ class CI {
     } else {
       return(this.generic())
     }
+  }
+
+  analytics_env() {
+    return this._stripUndefinedKeys({
+      "key": process.env.BUILDKITE_ANALYTICS_KEY,
+      "url": process.env.BUILDKITE_ANALYTICS_URL,
+      "branch": process.env.BUILDKITE_ANALYTICS_BRANCH,
+      "commit_sha": process.env.BUILDKITE_ANALYTICS_SHA,
+      "number": process.env.BUILDKITE_ANALYTICS_NUMBER,
+      "job_id": process.env.BUILDKITE_ANALYTICS_JOB_ID,
+      "message": process.env.BUILDKITE_ANALYTICS_MESSAGE,
+      "debug": process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED,
+      "version": version,
+      "collector": `js-${collector}`,
+    })
   }
 
   generic() {

--- a/src/ci.js
+++ b/src/ci.js
@@ -44,7 +44,7 @@ class CI {
       "message": process.env.BUILDKITE_ANALYTICS_MESSAGE,
       "debug": process.env.BUILDKITE_ANALYTICS_DEBUG_ENABLED,
       "version": version,
-      "collector": `js-${collector}`,
+      "collector": `js-${name}`,
     })
   }
 


### PR DESCRIPTION
The colllector was using `BUILDKITE_ANALYTICS_KEY` for both the API token and the run key resulting in the default CI run key being overridden by the API token. This manifested as all uploads belonging to a single monolithic run in the analytics suite.

I have renamed `BUILDKITE_ANALYTICS_KEY` as used for the API token to `BUILDKITE_ANALYTICS_API_TOKEN`. This restores `BUILDKITE_ANALYTICS_KEY` to it's intended purpose.

This PR reverts the changes to the CI variables in #1 to restore generic CI support and facilitate overriding of CI default environment variables. Link to docs about this support: https://buildkite.com/docs/test-analytics/integrations#environment-variables-rspec-on-other-ci-providers