### PR TITLE
Fix variable name

### DIFF
--- a/jest-reporter.js
+++ b/jest-reporter.js
@@ -113,7 +113,7 @@ class JestBuildkiteAnalyticsReporter {
   analyticsFailureReason(testResult) {
     if (testResult.status === 'failed') {
       // Strip ANSI color codes from messages
-      return result.failureMessages.join(' ').replace(/\u001b[^m]*?m/g,'')
+      return testResult.failureMessages.join(' ').replace(/\u001b[^m]*?m/g,'')
     }
   }
 }


### PR DESCRIPTION
`result` is not defined, it should be: `testResult`

It would be good to extract a lot of the logic in the jest reporter to different smaller classes which can be unit tested easily, for the moment though this simple fix will suffice.